### PR TITLE
feat: Add GitHub Actions workflow for Marp presentations

### DIFF
--- a/.github/workflows/marp-converter.yml
+++ b/.github/workflows/marp-converter.yml
@@ -1,0 +1,52 @@
+name: Marp Converter
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'report/**.md'
+
+jobs:
+  convert:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install Marp CLI
+        run: npm install -g @marp-team/marp-cli
+
+      - name: Convert Markdown files
+        run: |
+          mkdir -p output html
+          for file in $(find report/ -name '*.md'); do
+            BASENAME=$(basename "$file" .md)
+            echo "Processing $file -> output/$BASENAME.pptx, html/$BASENAME.html"
+            marp --allow-local-files --pptx "$file" -o "output/$BASENAME.pptx"
+            marp --allow-local-files --html "$file" -o "html/$BASENAME.html"
+          done
+
+      - name: Upload HTML artifact for deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./html
+
+  deploy:
+    needs: convert
+    permissions:
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/html/.gitkeep
+++ b/html/.gitkeep
@@ -1,0 +1,1 @@
+# This file is used to ensure the 'html' directory is tracked by Git.

--- a/output/.gitkeep
+++ b/output/.gitkeep
@@ -1,0 +1,1 @@
+# This file is used to ensure the 'output' directory is tracked by Git.

--- a/report/.gitkeep
+++ b/report/.gitkeep
@@ -1,0 +1,1 @@
+# This file is used to ensure the 'report' directory is tracked by Git.

--- a/report/your-presentation.md
+++ b/report/your-presentation.md
@@ -1,0 +1,13 @@
+# My Presentation
+
+---
+
+## Slide 1
+
+This is the first slide.
+
+---
+
+## Slide 2
+
+This is the second slide.


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow that automates the conversion of Marp Markdown files into PPTX and HTML formats.

Key features:
- Workflow triggers on pushes to the main branch when .md files in the `report/` directory are added or modified.
- For each Markdown file in `report/`:
    - A PPTX presentation is generated in the `output/` directory.
    - An HTML version is generated in the `html/` directory.
- The `html/` directory is deployed to GitHub Pages.

The necessary directories (`.github/workflows`, `report/`, `output/`, `html/`) have been created. A sample Marp presentation (`report/your-presentation.md`) is included to demonstrate the workflow.