### PR TITLE
feat: Add GitHub Actions workflow for Marp presentations

### DIFF
--- a/.github/workflows/marp-converter.yml
+++ b/.github/workflows/marp-converter.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '18'
 
       - name: Install Marp CLI
         run: npm install -g @marp-team/marp-cli


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow that automates the conversion of Marp Markdown files into PPTX and HTML formats, and deploys the HTML output to GitHub Pages.

Key features:
- Workflow triggers on pushes to the main branch when .md files in the `report/` directory are added or modified.
- For each Markdown file in `report/`:
    - A PPTX presentation is generated in the `output/` directory.
    - An HTML version is generated in the `html/` directory.
- The `html/` directory is deployed to GitHub Pages.
- The workflow uses Node.js v18 to ensure compatibility with Marp CLI.

The necessary directories (`.github/workflows`, `report/`, `output/`, `html/`) have been created. A sample Marp presentation (`report/your-presentation.md`) is included to demonstrate the workflow.

This also fixes a previous issue where the workflow failed due to an outdated Node.js version (v14) by updating it to v18, which is required by Marp CLI.