### PR TITLE
feat: Workflow now commits generated files and summary to main

### DIFF
--- a/.github/workflows/marp-converter.yml
+++ b/.github/workflows/marp-converter.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   convert:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -31,6 +33,39 @@ jobs:
             marp --allow-local-files --pptx "$file" -o "output/$BASENAME.pptx"
             marp --allow-local-files --html "$file" -o "html/$BASENAME.html"
           done
+
+      - name: Generate summary.html
+        run: |
+          echo "<html><head><title>Presentation Summary</title></head><body>" > summary.html
+          echo "<h1>Presentation Summary</h1><ul>" >> summary.html
+          for mdfile in $(find report/ -name '*.md' -type f); do
+            BASENAME=$(basename "$mdfile" .md)
+            HTML_FILE="html/$BASENAME.html"
+            PPTX_FILE="output/$BASENAME.pptx"
+            echo "<li><b>$BASENAME.md</b>" >> summary.html
+            echo "<ul>" >> summary.html
+            echo "<li><a href='$HTML_FILE'>View HTML</a></li>" >> summary.html
+            echo "<li><a href='$PPTX_FILE'>Download PPTX</a></li>" >> summary.html
+            echo "</ul></li>" >> summary.html
+          done
+          echo "</ul></body></html>" >> summary.html
+        shell: bash
+
+      - name: Commit generated files
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add summary.html html/ output/
+          # Check if there are changes to commit
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "docs: Auto-generate presentation files and summary
+
+          [skip ci] - Add this to prevent workflow recursion if not handled by path filtering"
+            git push
+          fi
+        shell: bash
 
       - name: Upload HTML artifact for deployment
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This commit finalizes the GitHub Actions workflow for Marp presentations. The workflow now performs the following:

1.  Triggers on changes to Markdown files in your `report/` directory on the `main` branch.
2.  Converts each Markdown file into:
    - An HTML file, stored in your `html/` directory.
    - A PPTX file, stored in your `output/` directory.
3.  Generates a `summary.html` file in the root of your repository. This summary lists all processed Marp files and provides direct links to their corresponding HTML and PPTX files within your `html/` and `output/` directories.
4.  Commits the contents of your `html/` and `output/` directories, along with the `summary.html` file, back to the `main` branch. This ensures all generated outputs are directly accessible in your repository. The commit is made by `github-actions[bot]` and includes `[skip ci]` to prevent workflow recursion.
5.  Deploys the contents of your `html/` directory to GitHub Pages.

The workflow uses Node.js v18 for compatibility with Marp CLI. Redundant artifact uploads for PPTX files have been removed as these files are now committed directly to your repository.

This setup allows you to:
- Have your Marp presentations automatically converted.
- Access the generated HTML and PPTX files directly from your `main` branch.
- View a summary page with convenient links to all outputs.
- Have your HTML presentations automatically published via GitHub Pages.