### PR TITLE
fix: Correct summary.html path for GitHub Pages deployment

### DIFF
--- a/.github/workflows/marp-converter.yml
+++ b/.github/workflows/marp-converter.yml
@@ -36,26 +36,32 @@ jobs:
 
       - name: Generate summary.html
         run: |
-          echo "<html><head><title>Presentation Summary</title></head><body>" > summary.html
-          echo "<h1>Presentation Summary</h1><ul>" >> summary.html
+          # Ensure html directory exists (it should, but good practice)
+          mkdir -p html
+
+          # Create summary.html inside html/
+          echo "<html><head><title>Presentation Summary</title></head><body>" > html/summary.html
+          echo "<h1>Presentation Summary</h1><ul>" >> html/summary.html
           for mdfile in $(find report/ -name '*.md' -type f); do
             BASENAME=$(basename "$mdfile" .md)
-            HTML_FILE="html/$BASENAME.html"
-            PPTX_FILE="output/$BASENAME.pptx"
-            echo "<li><b>$BASENAME.md</b>" >> summary.html
-            echo "<ul>" >> summary.html
-            echo "<li><a href='$HTML_FILE'>View HTML</a></li>" >> summary.html
-            echo "<li><a href='$PPTX_FILE'>Download PPTX</a></li>" >> summary.html
-            echo "</ul></li>" >> summary.html
+            # Links relative to html/summary.html
+            HTML_FILE_RELATIVE_PATH="./$BASENAME.html"
+            PPTX_FILE_RELATIVE_PATH="../output/$BASENAME.pptx"
+
+            echo "<li><b>$BASENAME.md</b>" >> html/summary.html
+            echo "<ul>" >> html/summary.html
+            echo "<li><a href='$HTML_FILE_RELATIVE_PATH'>View HTML</a></li>" >> html/summary.html
+            echo "<li><a href='$PPTX_FILE_RELATIVE_PATH'>Download PPTX</a></li>" >> html/summary.html
+            echo "</ul></li>" >> html/summary.html
           done
-          echo "</ul></body></html>" >> summary.html
+          echo "</ul></body></html>" >> html/summary.html
         shell: bash
 
       - name: Commit generated files
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add summary.html html/ output/
+          git add html/summary.html html/ output/ # summary.html is now in html/
           # Check if there are changes to commit
           if git diff --staged --quiet; then
             echo "No changes to commit."


### PR DESCRIPTION
This commit addresses an issue where summary.html was not accessible on the GitHub Pages site due to being generated in the repository root while Pages was serving from the 'html/' directory.

Changes include:
- Modified the workflow to generate 'summary.html' directly within the 'html/' directory (i.e., 'html/summary.html').
- Updated the internal links within 'summary.html' to be relative to its new location in the 'html/' directory. HTML links are now like './<filename>.html' and PPTX links are '../output/<filename>.pptx'.
- Ensured the commit step correctly includes 'html/summary.html' when committing generated files to the 'main' branch.

This ensures that 'summary.html' is deployed as part of the GitHub Pages site and is accessible, with its links functioning correctly. The overall process of converting Marp files, generating outputs, committing them to 'main', and deploying HTML to Pages remains intact.