### PR TITLE
feat: Implement clean-and-rebuild for output directories

### DIFF
--- a/.github/workflows/marp-converter.yml
+++ b/.github/workflows/marp-converter.yml
@@ -13,14 +13,24 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
       - name: Install Chinese fonts
         run: |
           sudo apt-get update -y
           sudo apt-get install -y fonts-noto-cjk
         shell: bash
 
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - name: Clean output directories
+        run: |
+          echo "Cleaning html/ directory..."
+          find html/ -mindepth 1 ! -name '.gitkeep' -exec rm -rf {} +
+          echo "Cleaning output/ directory..."
+          find output/ -mindepth 1 ! -name '.gitkeep' -exec rm -rf {} +
+          # Create the directories again in case .gitkeep was not present and they were fully removed
+          mkdir -p html output
+        shell: bash
 
       - name: Setup Node.js
         uses: actions/setup-node@v2

--- a/report/temp_for_delete_test.md
+++ b/report/temp_for_delete_test.md
@@ -1,0 +1,10 @@
+---
+marp: true
+theme: default
+---
+
+# Temporary Test File
+
+This file is for testing the deletion process.
+It should be automatically removed after its source is deleted.
+```


### PR DESCRIPTION
This commit introduces a "clean and rebuild" mechanism into the GitHub Actions workflow:

- Before each build, the 'html/' and 'output/' directories are cleaned (excluding .gitkeep files). This ensures that outputs from any previously deleted source Marp files are removed.
- The order of initial steps in the 'convert' job has been adjusted to ensure cleaning happens after checkout and before Node.js/Marp setup.
- A temporary file 'report/temp_for_delete_test.md' has been added to facilitate testing of this new deletion handling logic.

This change ensures that the state of the 'html/' and 'output/' directories in the main branch accurately reflects the current source files in the 'report/' directory.